### PR TITLE
Changed navbar and footer links

### DIFF
--- a/app/Navbar.tsx
+++ b/app/Navbar.tsx
@@ -151,7 +151,7 @@ function NavbarScroll({ isScrolling }: NavbarScrollProps) {
           <Link href={'/forum'}>Forum</Link>
         </li>
         <li className="px-4 py-2 ml-2 text-white bg-black rounded-full text-md ">
-          <Link href={'/account'}>Account</Link>
+          <Link href={'/forum/all-posts?page=1'}>All Posts</Link>
         </li>
       </ul>
     </motion.nav>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -13,7 +13,7 @@ const Footer = () => {
                 <ul className="text-md list-none -ml-[0.0px] flex flex-col gap-[12px]">
                     <a href="/forum"><li>Forum</li></a>
                     <a href="/"><li>For You</li></a>
-                    <a href="/"><li>All Posts</li></a>
+                    <a href="/forum/all-posts?page=1"><li>All Posts</li></a>
                 </ul>
             </div>
             <div className="flex flex-col gap-3">


### PR DESCRIPTION
1. The original navbar has 'All Posts' as one of the links but as soon as we scroll (i.e. it becomes floating), the text and link changes to account page
2. Changed the footer link to point to 'All Posts' page

Earlier

![image](https://github.com/founder-srm/ideaclinic_forum/assets/114401238/c1462808-6353-45e9-9807-e0bee3a2841b)

Updated

![image](https://github.com/founder-srm/ideaclinic_forum/assets/114401238/19f055b0-b4ce-4176-b597-929cad450383)